### PR TITLE
Update Tags.lua

### DIFF
--- a/Tags.lua
+++ b/Tags.lua
@@ -279,8 +279,6 @@ GBB.dungeonTagsLoc = {
   } ),
 }
 
-GBB.dungeonTagsLoc.enGB[ "DEADMINES" ] = { "dm" }
-
 GBB.dungeonSecondTags = {
   [ "DEADMINES" ] = { "DM", "-DMW", "-DME", "-DMN" },
   [ "SM2" ] = { "GY", "LIB", "ARMS", "CATH" },


### PR DESCRIPTION
Removed "GBB.dungeonTagsLoc.enGB[ "DEADMINES" ] = { "dm" }" from line 282 which was causing a doubleTag error